### PR TITLE
Double quotes branch name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ exec( 'git branch --no-color', function( error, stdout, stderr ) {
   }])
 
   prompt.then( function( results ) {
-    exec( "git checkout '" + results.branch + "'", {
+    exec( "git checkout \"" + results.branch + "\"", {
       cwd: process.cwd()
     }, function( error, stdout, stderr ) {
 


### PR DESCRIPTION
I had trouble with the single quotes around the branch name on a windows machine with GitBash. It seemed to be doubly single quoted and worked for me when I changed it to double quotes so I thought I'd send over PR, but can't say that I know how it'll work in other environments.