### PR TITLE
Don't insert empty array element

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -25,7 +25,7 @@ function checkout( branch ) {
     process.exit(1)
   }
 
-  exec( cmd([ 'git', 'checkout', ( branch.upstream ? '' : '--track' ), branch.refName ]), {
+  exec( cmd([ 'git', 'checkout' ].concat( branch.upstream ? [ '--track' ] : [], [ branch.refName ] )), {
     cwd: process.cwd(),
     env: process.env,
   }, function( error, stdout, stderr ) {


### PR DESCRIPTION
`cmd` inserts an empty quoted string `""` on Windows, which breaks checkout.