### PR TITLE
command line argument for local only, without arg processing lib

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -6,6 +6,10 @@ var elements = require( 'prompts/lib/elements' )
 var Fuse = require( 'fuse.js' )
 var argv = process.argv.slice( 2 )
 
+// handle argument for local only branches
+var all = argv.indexOf('--local') < 0
+argv = argv.filter(a => a !== '--local')
+
 // Make sure the terminal cursor doesn't stay hidden
 // after the program exits
 function exitHandler() {
@@ -63,7 +67,7 @@ function checkout( branch ) {
 var branchFormat = '%(HEAD)|%(refname)|%(refname:lstrip=2)|%(upstream)|%(upstream:remotename)|%(upstream:remoteref)|%(push)'
 var q = process.platform === 'win32' ? '"' : "'"
 
-exec( `git branch --list --all --no-color --sort=-committerdate --format=${q}${branchFormat}${q}`, function( error, stdout, stderr ) {
+exec( `git branch --list ${ all ? '--all' : ''} --no-color --sort=-committerdate --format=${q}${branchFormat}${q}`, function( error, stdout, stderr ) {
 
   var lines = stdout.trim().split( /\r?\n/g )
     .map( function( line, i ) {

--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -7,7 +7,7 @@ var Fuse = require( 'fuse.js' )
 var argv = process.argv.slice( 2 )
 
 // handle argument for local only branches
-var all = argv.indexOf('--local') < 0
+var remoteBranches = argv.indexOf('--local') < 0
 argv = argv.filter(a => a !== '--local')
 
 // Make sure the terminal cursor doesn't stay hidden
@@ -31,7 +31,7 @@ function checkout( branch ) {
 
   var checkoutCmd = [ 'git', 'checkout' ]
 
-  !branch.upstream ?
+  !branch.upstream && remoteBranches ?
     checkoutCmd.push( '--track', branch.refName ) :
     checkoutCmd.push( branch.refName )
 
@@ -67,7 +67,7 @@ function checkout( branch ) {
 var branchFormat = '%(HEAD)|%(refname)|%(refname:lstrip=2)|%(upstream)|%(upstream:remotename)|%(upstream:remoteref)|%(push)'
 var q = process.platform === 'win32' ? '"' : "'"
 
-exec( `git branch --list ${ all ? '--all' : ''} --no-color --sort=-committerdate --format=${q}${branchFormat}${q}`, function( error, stdout, stderr ) {
+exec( `git branch --list ${ remoteBranches ? '--all' : ''} --no-color --sort=-committerdate --format=${q}${branchFormat}${q}`, function( error, stdout, stderr ) {
 
   var lines = stdout.trim().split( /\r?\n/g )
     .map( function( line, i ) {


### PR DESCRIPTION
The library is awesome and this would help my workflow. The ability to filter branches to local only gives some more flexibility. Using a command line argument library would make a bunch more options configurable but add dependencies so this is a simple implementation. Cheers