### PR TITLE
Remove spaces from the branch names

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -98,7 +98,7 @@ exec( `git branch --list ${ remoteBranches ? '--all' : ''} --no-color --sort=-co
   // Materialize result list for search & prompt
   var results = []
   for( var [ ref, branch ] of branches ) {
-    results.push({ title: `  ${branch.refName}`, value: branch })
+    results.push({ title: branch.refName, value: branch })
   }
 
   var fuse = new Fuse( results, {


### PR DESCRIPTION
I was about to write this exact tool, but found yours, so thank you!  As a ux/design guy the spaces before the branch name bother me and I'm not sure what their purpose is.  Given that there is a `>` cursor indicating which line you're on, and it changes the color and underlines the branch name, it seems a bit clunky.  Nitpicky, but I think it'd make for cleaner output :)