### PR TITLE
Search for branches recursively (to support branches with '/')

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -56,16 +56,32 @@ const GIT_HEADS = path.join( REPO_PATH, 'refs', 'heads' )
 const GIT_REMOTES = path.join( REPO_PATH, 'refs', 'remotes' )
 const GIT_TAGS = path.join( REPO_PATH, 'refs', 'tags' )
 
-function readHeads( basename, remote ) {
+function searchHeads(dirname, ref, remote) {
 
-  var dirname = path.join( process.cwd(), basename )
+  var heads = []
 
-  return fs.readdirSync( dirname )
-    .filter(( ref ) => ref != 'HEAD')
-    .map(( ref ) => {
-      var filename = path.join( dirname, ref )
-      return { remote, name: ref, commit: fs.readFileSync( filename, 'utf8' ).trim() }
-    })
+  var filename = path.join(dirname, ref)
+  if (fs.lstatSync(filename).isDirectory()) {
+    fs.readdirSync(filename).forEach((suffix) => {
+      let new_ref = path.join(ref, suffix)
+      heads.push(...searchHeads(dirname, new_ref, remote))
+    });
+  } else {
+    var filename = path.join(dirname, ref)
+    heads.push({ remote, name: ref, commit: fs.readFileSync(filename, 'utf8').trim() })
+  }
+
+  return heads
+
+}
+
+function readHeads(basename, remote) {
+
+  var dirname = path.join(process.cwd(), basename)
+
+  return fs.readdirSync(dirname)
+    .filter((ref) => ref != 'HEAD')
+    .flatMap((ref) => searchHeads(dirname, ref, remote))
 
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-branch-select",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Git plugin for interactive branch listing, selection & checkout",
   "author": "Jonas Hermsmeier <jhermsmeier@gmail.com> (https://jhermsmeier.de)",
   "license": "MIT",


### PR DESCRIPTION
Adding a `searchHeads` function to recursively search for branches in `.git/refs/head`. Branch names can be nested (with "/" in the name to separate each level) and this new function will find all terminal branch names and present them to the user:

Fixes #20 

Given the following branches:
```
❯ git branch
  features/123/main
  hotfix/456
  master
* support-nested-branches
```

Running `git-branch-select`:
```
❯ node bin/git-branch-select
? Select a branch: › 
❯   features/123/main
    hotfix/456
    master
    support-nested-branches
```

And choosing on a nested branch
```
❯ node bin/git-branch-select                            
✔ Select a branch: › hotfix/456
Switched to branch 'hotfix/456'

mat on thepacketgeek in git-branch-select on  hotfix/456 via ⬢ v14.7.0
❯ 
```