### PR TITLE
Discover git root to allow for branch-select from repo subdirectories

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -36,9 +36,11 @@ if( argv.includes( '-h' ) || argv.includes( '--help' ) ) {
   process.exit( 0 )
 }
 
-var REPO_PATH = '.git'
+var exec = require('child_process').execSync
 
 try {
+  var REPO_ROOT = exec("git rev-parse --show-toplevel").toString().trim();
+  var REPO_PATH = path.join(REPO_ROOT, '.git')
   var stats = fs.lstatSync( REPO_PATH )
   if( stats.isSymbolicLink() ) {
     REPO_PATH = fs.readlinkSync( REPO_PATH, { encoding: 'utf8' })
@@ -77,7 +79,7 @@ function searchHeads(dirname, ref, remote) {
 
 function readHeads(basename, remote) {
 
-  var dirname = path.join(process.cwd(), basename)
+  var dirname = basename
 
   return fs.readdirSync(dirname)
     .filter((ref) => ref != 'HEAD')
@@ -87,7 +89,7 @@ function readHeads(basename, remote) {
 
 function readRemotes() {
 
-  var dirname = path.join( process.cwd(), GIT_REMOTES )
+  var dirname = GIT_REMOTES
   var remotes = []
 
   fs.readdirSync( dirname ).forEach(( remote ) => {


### PR DESCRIPTION
Currently `git-branch-select` assumes it's operating in the repo root (`.git` directory is present). This diff adds a discovery of the git root directory by running `git rev-parse --show-toplevel` to allow usage of git-branch-select from subdirectories in the repo:

Use Case: In a monorepo, change branches without changing to git root directory

From repo root:
```
❯ pwd
/home/mat/git-branch-select

❯ node bin/git-branch-select 
? Select a branch: › 
❯   discover-git-root
    features/123/main
    hotfix/456
    master
```

From subdirectory:
```
❯ cd bin
❯ pwd
/home/mat/git-branch-select/bin

❯ node ./git-branch-select 
? Select a branch: › 
❯   discover-git-root
    features/123/main
    hotfix/456
    master
```