### PR TITLE
bin: Fix the ref concatination for Win systems

### DIFF
--- a/bin/git-branch-select
+++ b/bin/git-branch-select
@@ -65,7 +65,7 @@ function searchHeads(dirname, ref, remote) {
   var filename = path.join(dirname, ref)
   if (fs.lstatSync(filename).isDirectory()) {
     fs.readdirSync(filename).forEach((suffix) => {
-      let new_ref = path.join(ref, suffix)
+      const new_ref = [ref, suffix].join('/');
       heads.push(...searchHeads(dirname, new_ref, remote))
     });
   } else {


### PR DESCRIPTION
I have installed this tool and in general it works great. But I am using the directory branch names (eg. `feature/something`) and it seems to not work on Windows in PowerShell and cmd. It was not selecting the branches that had a delimiter.

The problem is that Node on Windows uses a path delimiter as `\`, but git actually does not allow `\` in branch names. It only works with `/`, irregardless of the platform. So instead of having a platform agnostic delimiter, it makes sense to use a "hardcoded" one for ref names.

More details on this are here: https://git-scm.com/docs/git-check-ref-format
